### PR TITLE
Add privacy policy page for Watch Identifier app

### DIFF
--- a/watchid-pp.html
+++ b/watchid-pp.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Watch Identifier</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+        }
+        .container {
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { color: #455A64; } /* Matching your Steel brand */
+        h2 { margin-top: 30px; color: #444; }
+        p { margin-bottom: 15px; }
+        ul { margin-bottom: 15px; }
+        li { margin-bottom: 8px; }
+        .contact {
+            background-color: #eceff1;
+            padding: 15px;
+            border-radius: 4px;
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <h1>Privacy Policy</h1>
+    <p><strong>Effective Date:</strong> September 1, 2026</p>
+
+    <p>
+        Thank you for using <strong>Watch Identifier</strong>. We respect your privacy and are committed to
+        protecting it. This Privacy Policy explains what information Watch Identifier and the third-party
+        services it relies on collect, and how that information is used.
+    </p>
+
+    <h2>1. Your Photos</h2>
+    <p>
+        To identify a watch, you capture a photo with your camera or choose one from your gallery. That photo
+        is resized and compressed on your device before it ever leaves it, then sent to a small server we
+        operate (a Cloudflare Worker), which forwards it to Anthropic's Claude API to generate the
+        identification result (brand, model, reference and an estimated resale range).
+    </p>
+    <p>
+        <strong>We do not store your photos.</strong> Our server uses the photo only to produce the
+        identification result and discards it immediately afterwards; our server logs record only
+        operational metadata (timing and success/failure), never the image itself. Under Anthropic's API
+        terms, photos submitted this way are not used to train Anthropic's models.
+        <br>
+        <a href="https://www.anthropic.com/legal/privacy" target="_blank" rel="noopener">Anthropic Privacy Policy</a>
+    </p>
+
+    <h2>2. Your Collection Stays on Your Device</h2>
+    <p>
+        Saved identifications, notes, and your personal watch collection are stored locally on your device
+        and are never uploaded to us or to any third party. If you uninstall the app or clear its data, this
+        information is permanently lost — we have no copy of it.
+    </p>
+
+    <h2>3. Permissions</h2>
+    <p>The app may request the following permissions, used strictly for the purposes below:</p>
+    <ul>
+        <li><strong>Camera:</strong> to take a photo of a watch to identify.</li>
+        <li><strong>Photos/Storage:</strong> to let you choose an existing photo instead of the camera.</li>
+        <li><strong>Notifications:</strong> optional, requested after your first successful scan, to send
+            occasional reminders about the app.</li>
+    </ul>
+
+    <h2>4. Third-Party Services</h2>
+    <p>
+        Watch Identifier uses the following third-party services, which may collect information as described
+        below. These services are operated by their respective providers under their own privacy policies.
+    </p>
+    <ul>
+        <li>
+            <strong>Anthropic (Claude API):</strong> processes the photo you submit to generate the watch
+            identification result, as described in Section 1 above.
+            <br>
+            <a href="https://www.anthropic.com/legal/privacy" target="_blank" rel="noopener">Anthropic Privacy Policy</a>
+        </li>
+        <li>
+            <strong>Firebase Analytics (Google):</strong> collects app usage and event data (e.g. which
+            features are used, scan and paywall events) to help us understand how the app is used and improve
+            it. This data is associated with a device/app-instance identifier, not your name or email. We do
+            not collect the Advertising ID.
+            <br>
+            <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Firebase Privacy and Security</a>
+        </li>
+        <li>
+            <strong>Firebase Crashlytics (Google):</strong> collects crash reports, including device
+            information (model, OS version) and stack traces, to help us diagnose and fix bugs.
+            <br>
+            <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Firebase Privacy and Security</a>
+        </li>
+        <li>
+            <strong>Firebase Cloud Messaging (Google):</strong> if you allow notifications, we use your
+            device's messaging token to deliver occasional push notifications. We do not use this token for
+            any other purpose.
+            <br>
+            <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Firebase Privacy and Security</a>
+        </li>
+        <li>
+            <strong>RevenueCat:</strong> if you purchase Watch Identifier Pro, RevenueCat processes your
+            purchase and entitlement status (e.g. whether Pro is active) so the app can unlock the
+            corresponding features. RevenueCat does not receive your photos.
+            <br>
+            <a href="https://www.revenuecat.com/privacy" target="_blank" rel="noopener">RevenueCat Privacy Policy</a>
+        </li>
+        <li>
+            <strong>Google Play Billing:</strong> if you purchase Watch Identifier Pro, the purchase itself
+            (including your payment method and billing details) is handled entirely by Google Play. Watch
+            Identifier and its developer never see or store your payment information.
+            <br>
+            <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google Privacy Policy</a>
+        </li>
+    </ul>
+    <p>
+        Google (for Firebase Analytics, Crashlytics and Cloud Messaging), Anthropic and RevenueCat each act
+        as independent data processors under their own standard Data Processing Agreements, which apply
+        automatically to all customers using their services — we do not need a separately negotiated DPA
+        with any of them.
+    </p>
+
+    <h2>5. Legal Basis for Processing (EEA/UK Users)</h2>
+    <p>
+        If you are located in the European Economic Area, the UK, or another jurisdiction requiring a
+        stated legal basis, we (and our processors) rely on:
+    </p>
+    <ul>
+        <li><strong>Performance of a contract</strong> — for processing your photo through Anthropic's Claude
+            API to generate the identification result you requested, and for RevenueCat and Google Play
+            Billing to process your Pro purchase and grant the corresponding entitlement;</li>
+        <li><strong>Legitimate interests</strong> — for Firebase Analytics and Crashlytics, to understand app
+            usage and diagnose crashes so we can maintain and improve the App;</li>
+        <li><strong>Consent</strong> — for Firebase Cloud Messaging, which only activates after you grant the
+            notification permission.</li>
+    </ul>
+    <p>
+        We do not rely on consent as the legal basis for analytics or crash reporting; where local law
+        requires opt-in consent for non-essential analytics (e.g. under ePrivacy rules), we will provide a
+        consent mechanism before those services activate.
+    </p>
+
+    <h2>6. International Data Transfers</h2>
+    <p>
+        The third-party services listed above (Anthropic, Google/Firebase, RevenueCat) may process data on
+        servers located outside your country, including in the United States. These providers rely on the
+        EU Standard Contractual Clauses (and, for Google, certification under the EU-U.S. Data Privacy
+        Framework) as the legal mechanism for these transfers. By using the App, you acknowledge this
+        transfer.
+    </p>
+
+    <h2>7. Data Retention</h2>
+    <p>We retain data for only as long as necessary:</p>
+    <ul>
+        <li><strong>Photos:</strong> not retained — discarded immediately after the identification result is
+            generated;</li>
+        <li><strong>Your collection, notes and scan history:</strong> stored only on your device, for as
+            long as you keep the app installed;</li>
+        <li><strong>Firebase Analytics:</strong> event and user-level data is retained for 14 months from
+            collection, matching Firebase's default retention setting;</li>
+        <li><strong>Firebase Crashlytics:</strong> crash reports are retained for 90 days;</li>
+        <li><strong>RevenueCat / purchase records:</strong> your entitlement status is retained for as long
+            as you have the App installed and, after that, for up to 7 years to satisfy standard financial
+            and tax record-keeping obligations.</li>
+    </ul>
+
+    <h2>8. Your Rights</h2>
+    <p>
+        Depending on where you live, you have rights over the data collected about you by the third-party
+        services described above.
+    </p>
+    <p><strong>If you are in the EEA, UK, or a similar jurisdiction (GDPR), you have the right to:</strong></p>
+    <ul>
+        <li>Access the data held about you;</li>
+        <li>Correct inaccurate data;</li>
+        <li>Request erasure of your data ("right to be forgotten");</li>
+        <li>Restrict or object to certain processing;</li>
+        <li>Receive your data in a portable format;</li>
+        <li>Lodge a complaint with your local data protection supervisory authority.</li>
+    </ul>
+    <p><strong>If you are a California resident (CCPA/CPRA), you have the right to:</strong></p>
+    <ul>
+        <li>Know what personal information is collected, used, and disclosed;</li>
+        <li>Request deletion of your personal information;</li>
+        <li>Correct inaccurate personal information;</li>
+        <li>Non-discrimination for exercising any of these rights.</li>
+    </ul>
+    <p><strong>If you are in Brazil (LGPD — Lei Geral de Proteção de Dados), you have the right to:</strong></p>
+    <ul>
+        <li>Confirm whether we (or our processors) hold data about you, and access it;</li>
+        <li>Correct incomplete, inaccurate, or outdated data;</li>
+        <li>Request anonymization, blocking, or deletion of unnecessary or excessive data, or data
+            processed without a valid legal basis;</li>
+        <li>Receive your data in a portable format;</li>
+        <li>Be informed of the public and private entities with which we share your data (see Third-Party
+            Services above);</li>
+        <li>Revoke consent, where consent is the legal basis relied on, and request deletion of data
+            processed on that basis;</li>
+        <li>Lodge a complaint with the Autoridade Nacional de Proteção de Dados (ANPD).</li>
+    </ul>
+    <p>
+        <strong>We do not sell or share personal information</strong> for cross-context behavioral
+        advertising, so there is no "opt-out of sale/share" to exercise.
+    </p>
+    <p>
+        To exercise any of these rights, contact us at the email below; we aim to respond within 30 days
+        (15 days for LGPD access requests, extendable once with justification). You may also exercise
+        rights over a specific processor's own data directly with that processor (links in the Third-Party
+        Services section above). As a solo developer with only occasional, low-risk processing of the kind
+        described in this policy, we rely on the Article 27 GDPR exemption from appointing a dedicated EU
+        representative.
+    </p>
+
+    <h2>9. Children's Privacy</h2>
+    <p>
+        Watch Identifier is a general-audience app, not directed at children, and we do not knowingly
+        collect personal information from children under 13 (or the minimum age of digital consent in your
+        country, where higher). Our Google Play Data Safety declaration reflects this. If we learn that a
+        child has provided us with personal information through Firebase Analytics or Crashlytics, we will
+        take steps to delete it; contact us at the email below if you believe this has occurred.
+    </p>
+
+    <h2>10. Security</h2>
+    <p>
+        Photos are transmitted over an encrypted connection and discarded after processing, and your
+        collection data never leaves your device. Data collected by the third-party services above is
+        protected by their own security measures; no method of transmission or storage is 100% secure.
+    </p>
+
+    <h2>11. Changes to This Policy</h2>
+    <p>
+        We may update this Privacy Policy from time to time as the app's features or the third-party
+        services it uses change. Material changes will be reflected here with an updated effective date.
+        You are advised to review this page periodically.
+    </p>
+
+    <h2>12. Contact Us</h2>
+    <div class="contact">
+        <p>If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact the developer:</p>
+        <p><strong>Data Controller:</strong> Gabriel Machado, São Paulo, Brazil</p>
+        <p><strong>Email:</strong> <a href="mailto:machadowg@gmail.com">machadowg@gmail.com</a></p>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `watchid-pp.html` at the site root, matching the existing per-app `-pp.html` convention (`sonnet-pp.html`, `lilol-pp.html`)
- Hosts the privacy policy for the new Watch Identifier Android app (`dev.machado001.watchid`)
- Once merged, it will be served at `https://machado001.github.io/watchid-pp.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN9qfdvFnEoXZRBkwddSqQ